### PR TITLE
Grammar updates to whitepaper.md

### DIFF
--- a/whitepaper.md
+++ b/whitepaper.md
@@ -4,7 +4,7 @@ Factom
 Abstract
 --------
 
-Factom is an open source project which leverages the irreversible security of the Bitcoin Blockchain.  Multiple user's data is collected by the system and is packaged with other user's data.  The entire set of data is distilled to a single hash which is placed in the Bitcoin Blockchain.  The data package is then published on a peer-to-peer network, allowing users to download the entire set of timestamps.
+Factom is an open source project which leverages the irreversible security of the Bitcoin Block Chain ("blockchain").  Multiple user's data is collected by the Factom system and is packaged with other user's data.  The entire set of data is distilled to a single hash which is placed in the blockchain.  The data package is then published on a peer-to-peer network, allowing users to download the entire set of timestamps.
 
 Factom secures the entries by creating a hierarchical system of blocks and hashes culminating into a single hash every ten minutes.  This single hash is placed into the Bitcoin blockchain.  These structures holding and securing the entries are shared on an P2P network, using a BitTorrent like protocol.  The structures are arranged in a hierarchy, allowing for compact proofs.  The arrangement also allows users to download only the data subset they are interested in, and still be able to create proofs on their data, such as proofs of the negative (the hash of this document is not in the ledger).
  
@@ -17,17 +17,17 @@ Introduction
 
 When Satoshi Nakamoto launched the Bitcoin blockchain he revolutionized the way transactions were recorded. There had never before existed a permanent, decentralized, and trustless ledger of records. Developers have rushed to create applications built on top of this ledger. Unfortunately, they run into a few core problems that were not anticipated when the blockchain was launched:
 
-1)	Speed – because of it’s decentralized nature, the Bitcoin blockchain takes roughly 10 minutes to confirm a transaction. Many applications require multiple confirmations for security.  Many applications can’t deliver a practical user experience with this time constraint. 
+1)	Speed – because of its decentralized nature, the blockchain takes roughly 10 minutes to confirm a transaction. Many applications require multiple confirmations for security.  Many applications can’t deliver a practical user experience with this time constraint. 
 
 2)	Cost – the current minimum transaction cost is around 100 Bits (or roughly $0.05). The exchange price of Bitcoins has increased approximately 500% in the last 12 months ending August 2014, and is projected to continue to increase long term. This provides a serious cost barrier to applications that need to manage millions of transactions. (For conversions between USD, BTC, mBTC, and bits, check out this [Bitcoin Price Converter](http://youmeandbtc.com/bitcoin-converter/).)
 
-3)	Bloat – the Bitcoin blockchain currently has a 1 MB block size limit which caps it at 7 transactions per second. Any application that wants to write and store information using the Bitcoin blockchain will add to the traffic. This problem has become politically charged. Should the Bitcoin blockchain be used for non-BTC transactions, or should it stay pure?
+3)	Bloat – the Bitcoin blockchain currently has a 1 MB block size limit which caps it at 7 transactions per second. Any application that wants to write and store information using the blockchain will add to the traffic. This problem has become politically charged. Should the blockchain be used for non-BTC transactions, or should it stay pure?
 
 Factom is a protocol designed to solve these three core problems. Factom creates a Protocol Stack for Bitcoin 2.0 applications and constructs a simple, standard, effective, and secure foundation for these applications to run faster, cheaper, and bloat-free. 
 
 ------------
 
-Bitcoin is disrupting the status quo for online payments.  With Bitcoin, payments can be made worldwide without any centralized party.  The success and elegance of Bitcoin has inspired many others to seek ways of decentralizing more than just payment systems.  Many have observed that the blockchain could enable the trading of commodities, trading of assets, issuing  securities, implementing self enforcing smart contracts, crowd sourced loans, etc.  The set of such extended applications is often referred to as "Bitcoin 2.0"
+Bitcoin is disrupting the status quo for online payments.  With Bitcoin, payments can be made worldwide without any centralized party.  The success and elegance of Bitcoin has inspired many others to seek ways of decentralizing more than just payment systems.  Many have observed that the blockchain could enable the trading of commodities, trading of assets, issuing  securities, implementing self enforcing smart contracts, crowd sourced loans, etc.  The set of such extended applications is often referred to as "Bitcoin 2.0".
 
 Factom simplifies how Bitcoin 2.0 applications can be deployed.  Factom does so by providing a few simple operators from which many more complicated designs can be built.  Factom extends Bitcoin beyond the exchange of bitcoins to include the recording and management of arbitrary events, and chains of such events.
 
@@ -64,7 +64,7 @@ Data is organized into block structures, and combined via a Merkle trees.  Every
 
 Bitcoin block time stamps themselves have a fluid idea of time.  They have a 2 hour flexibility from reality [1].  Factom will provide its own internal time stamps which conform with standard time systems.  Since Factom places high importance on time stamping, it will be a closely audited part of the system.
 
-The user data time stamps will be assigned when they are received at the server.  A federated server network bounds the assigned server to within a 1 minute time frame.  The server is not allowed to time stamp outside of that time frame.  The time spans between when a Factom block is opened and when it is closed. On closing, the federated server network generates consensus and cumulatively time stamp each other's data.
+The user data time stamps will be assigned when they are received at the server.  A federated server network bounds the assigned server to within a 1 minute time frame.  The server is not allowed to time stamp outside of that time frame.  The time spans between when a Factom block is opened and when it is closed. On closing, the federated server network generates consensus and cumulatively time stamps each other's data.
 
 As a general note, the data could have existed long before it was time stamped.  Factom only proves the data did not originate after the time stamp.
 
@@ -72,18 +72,18 @@ The Merkle Root for the Factom block (effectively a time stamp) is entered into 
 
 The Merkle Root time stamp will be entered into the Bitcoin blockchain by one of the members in the federation.  The server delegated to time stamp the federation’s collected data creates a small BTC transaction.  The transaction will be broadcast to the Bitcoin network, and be included in a Bitcoin block.  
 
-Bitcoin blocks are generated with a statistical process, as such, their timing cannot be predicted.  This means that the time stamping done for entries within Factom is only roughly bound by the entries inserted into the Bitcoin block chain, and thus Bitcoin time stamping system.  The real value of inserting these values  into Bitcoin is to prevent anyone from generating false Factom histories in the future.  Due to bad luck of Bitcoin miners, or slow inclusion of Factom transactions, there could easily be an hour or more between when the Factom state is frozen for a particular Factom block and when the Bitcoin transaction that secures that Factom block is mined into a Bitcoin block.
+Bitcoin blocks are generated with a statistical process, as such, their timing cannot be predicted.  This means that the time stamping done for entries within Factom is only roughly bound by the entries inserted into the Bitcoin blockchain, and thus Bitcoin time stamping system.  The real value of inserting these values  into Bitcoin is to prevent anyone from generating false Factom histories in the future.  Due to bad luck of Bitcoin miners, or slow inclusion of Factom transactions, there could easily be an hour or more between when the Factom state is frozen for a particular Factom block and when the Bitcoin transaction that secures that Factom block is mined into a Bitcoin block.
 
 
 **Factom Layer**
 
 The Factom layer implements proof of existence for an digital artifact.  Any event, document, image, recording, etc. that is defined in a digital representation can be hashed.  That hash can be recorded in the Factom layer.  Because of the vast (currently insurmountable) difficulty and complexity of creating a digital document that will generate a particular hash, the mere recording of such a hash is proof of the digital document’s existence at the time of the recording of the hash.
 
-Factom collects sets of such hashes into a Factom block.  The Factom block is then hashed by computing a Merkle tree, and the Merkle root is recorded into the Bitcoin block chain.  This allows the most minimum expansion of the Bitcoin block chain, yet the ledger itself becomes as secure as Bitcoin itself.  Furthermore, since Factom can be maintained more cheaply in terms of resources, the cost of entries into the Factom layer will be much cheaper than transactions in the Bitcoin block chain.
+Factom collects sets of such hashes into a Factom block.  The Factom block is then hashed by computing a Merkle tree, and the Merkle root is recorded into the Bitcoin blockchain.  This allows the most minimum expansion of the blockchain, yet the ledger itself becomes as secure as Bitcoin itself.  Furthermore, since Factom can be maintained more cheaply in terms of resources, the cost of entries into the Factom layer will be much cheaper than transactions in the blockchain.
 
 **Entry Layer**
 
-Bitcoin 2.0 applications will need to record a varied range of information associated with events within their application.   The information associated with an event can be encoded into an Entry and the entry recorded into Factom.  Encoding all that information into the Bitcoin block chain is unreasonable, yet some applications need information recorded into the ledger rather than holding that information off chain.   Factom allow the application to define the entry structure(s) they require, and manage the structure(s) in Factom Chains. 
+Bitcoin 2.0 applications will need to record a varied range of information associated with events within their application.   The information associated with an event can be encoded into an Entry and the entry recorded into Factom.  Encoding all that information into the Bitcoin blockchain is unreasonable, yet some applications need information recorded into the ledger rather than holding that information off chain.   Factom allow the application to define the entry structure(s) they require, and manage the structure(s) in Factom Chains. 
 
 **Factom Chains**
 
@@ -123,7 +123,7 @@ Using these operators and facilities, Distributed Autonomous Applications (DAPPs
 
 #Discussion
 
-Using Bitcoin to prove the existence of a document (really any digital asset, like a tweet, a web page, a spreadsheet, a security video, a photo, etc.) is a concept that is well known.  (See the references at the end of this document).  And some have even suggested that a service could be created to take a list of signatures, compute a merkle root, place that in the Bitcoin block chain.  This not only provides the same security, but limits the “block chain Pollution” of pushing a hash into the blockchain for every signed document.  There are at least a couple of online websites that provide these services.
+Using Bitcoin to prove the existence of a document (really any digital asset, like a tweet, a web page, a spreadsheet, a security video, a photo, etc.) is a concept that is well known.  (See the references at the end of this document).  And some have even suggested that a service could be created to take a list of signatures, compute a merkle root, place that in the Bitcoin blockchain.  This not only provides the same security, but limits the “blockchain pollution” of pushing a hash into the blockchain for every signed document.  There are at least a couple of online websites that provide these services.
 
 Factom provide for simple “proof of existence” entries.  In addition, Factom provide proof of transform.  Factom implement validation scripts that allow for chains of notarized entries.   Factom can be used to implement token systems, asset trading systems, smart contracts, and more.   A federated set of FactomChain servers provide for real time audits, easy transfer from one FactomChain server to another, reduced blockchain pollution, and other benefits.
 
@@ -133,33 +133,33 @@ The Bitcoin protocol is transactionally complete.  In other words, the creation 
 
 Many different groups are looking to find ways to leverage the Bitcoin approach for managing other sorts of transactions besides tracking bitcoin balances.  For example, the trading of assets such as houses or cars can be done digitally using Bitcoin.  Even the trading of Commodities such as precious metals, futures, or securities might be done via clever encoding and inserting of information into the Bitcoin blockchain.  
 
-Efforts to expand Bitcoin to cover these kinds of trades include Colored Coins,  Mastercoin, and Counterparty.  Others seek to build their own cryptocurrency with a more flexible protocol that can handle trades beyond currency.  These include Namecoin, Ripple, Etherium, BitShares, NXT, and others.  And of course Open Transactions uses Cryptographic signatures and signed receipts and proof of balance for users (i.e. a user does not need the transaction history to prove their balance, just the last receipt). 
+Efforts to expand Bitcoin to cover these kinds of trades include Colored Coins,  Mastercoin, and Counterparty.  Others seek to build their own cryptocurrency with a more flexible protocol that can handle trades beyond currency.  These include Namecoin, Ripple, Etherium, BitShares, NXT, and others.  And of course Open Transactions uses Cryptographic signatures and signed receipts and proof of balance for users (i.e., a user does not need the transaction history to prove their balance, just the last receipt). 
 
-A FactomChain seeks to gain the ability to track assets and implement contracts, while securing the advantage Bitcoin’s security via Bitcoin block chain.  Instead of inserting transactions into the Blockchain (viewed as “Blockchain Pollution” by many), Factom keep most information off blockchain.  Furthermore, the FactomChain provides a record keeping system that minimizes the information any actor has to maintain to validate their Factom of interest.  In short,   Factom utilize a combination of mathematical proofs and hashes within the Factom, while inserting the least amount of information into Bitcoin block chain.  The goal is to create an system of records whose audit trails can prove the interactions of FactomChain users.
+A FactomChain seeks to gain the ability to track assets and implement contracts, while securing the advantage Bitcoin’s security via Bitcoin blockchain.  Instead of inserting transactions into the blockchain (viewed as “blockchain pollution” by many), Factom keeps most information off blockchain.  Furthermore, the FactomChain provides a record keeping system that minimizes the information any actor has to maintain to validate their Factom of interest.  In short,   Factom utilize a combination of mathematical proofs and hashes within the Factom, while inserting the least amount of information into blockchain.  The goal is to create an system of records whose audit trails can prove the interactions of FactomChain users.
 
 A user only needs the artifacts of the FactomChain of interest rather than the full set of Factom maintained by the FactomChain servers.
 
-Of course, the FactomChain can notarize documents, providing proof of their existence at a point in time, and validating their construction (any modification will be detected).  In addition, a FactomChain provides a provable history, a chain of time stamped events, i.e. a series of entries (i.e. a FactomChain) that proves a series of events occurred.   This allows a FactomChain to implement smart contracts and even alternate currencies.  All of which can clear instantly (assuming trust in the FactomChain servers), and within minutes once a Factom entry is secured via the Bitcoin Blockchain.
+Of course, the FactomChain can notarize documents, providing proof of their existence at a point in time, and validating their construction (any modification will be detected). In addition, a FactomChain provides a history that proves a series of events occurred. The FactomChain is a series of entries that form a chain of time-stamped events, providing a provable history.  This allows a FactomChain to implement smart contracts and even alternate currencies.  All of which can clear instantly (assuming trust in the FactomChain servers), and within minutes once a Factom entry is secured via the blockchain.
 
-The Factom are maintained on a set of federated, independently controlled FactomChain servers.  Factom borrows from the concept of Private Chains, and allows for reactive security by limiting the ability of any FactomChain server to fail to log entries without immediate detection by not only the other FactomChain servers, but by the users themselves.  And like Open Transactions, all links in a chain are secured with cryptographic signatures; there is no opportunity for a FactomChain server to insert a bogus transaction. 
+The FactomChains are maintained on a set of federated, independently controlled FactomChain servers.  Factom borrows from the concept of Private Chains, and allows for reactive security by limiting the ability of any FactomChain server to fail to log entries without immediate detection by not only the other FactomChain servers, but by the users themselves.  And like Open Transactions, all links in a chain are secured with cryptographic signatures; there is no opportunity for a FactomChain server to insert a bogus transaction. 
 
 Furthermore, a FactomChain is largely left ignorant of the significance of any transaction.  The management and backing of any FactomChain is left to the users of the service.  The FactomChain is an automated, powerless, and disinterested party to the transformations of a particular FactomChain.
 
-The FactomChain concept is designed to allow many different protocols and rules to be run in parallel within data structures designed and implemented by its users.  At the same time, the integrity of the system is secured with the Bitcoin block chain.  Factom also limit the amount of “pollution” to the blockchain that would result if the same data and information were encoded into Bitcoin Transactions.  Additionally, the FactomChain seeks to reduce the overhead of a single blockchain for sets of transactions that have little to do with one another.  In other words, while Bitcoin benefits from thousands of computers holding the full blockchain, many applications simply need to be auditable, with far fewer systems holding the entire Factom History.  Thus Factom significantly reduce the resources required to process transactions while providing nearly instant transaction clearing.  Federated FactomChain Servers provide for distributing FactomChain processing, load balancing, real time audits to insure honesty, and redundancy to insure availability.
+The FactomChain concept is designed to allow many different protocols and rules to be run in parallel within data structures designed and implemented by its users.  At the same time, the integrity of the system is secured with the Bitcoin blockchain.  Factom also limits the amount of “pollution” to the blockchain that would result if the same data and information were encoded into Bitcoin Transactions.  Additionally, the FactomChain seeks to reduce the overhead of a single blockchain for sets of transactions that have little to do with one another.  In other words, while Bitcoin benefits from thousands of computers holding the full blockchain, many applications simply need to be auditable, with far fewer systems holding the entire Factom History.  Thus Factom significantly reduces the resources required to process transactions while providing nearly instant transaction clearing.  Federated FactomChain Servers provide for distributing FactomChain processing, load balancing, real time audits to insure honesty, and redundancy to insure availability.
 
-Initially, FactomChain servers will provide APIs to query information from the FactomChain as needed.  Tools for analyzing the FactomChain and torrents for distributing the FactomChain will also be provided.  As technologies such as MaidSafe and the Safe Network come online, then FactomChain data can be published there in a way that insures all the Factom Blocks are available going forward, despite the fate of any particular FactomChain Server.
+Initially, FactomChain servers will provide APIs to query information from the FactomChain as needed.  Tools for analyzing the FactomChain and torrents for distributing the FactomChain will also be provided.  As technologies such as MaidSafe and the SAFE Network come online, then FactomChain data can be published there in a way that insures all the Factom Blocks are available going forward, despite the fate of any particular FactomChain Server.
 
 Yet even if the data in FactomChain servers expand to many terabytes in size, the validity of Factom Entries and particular Factom Chains are only going to require a small portion of that data.
 
-#How Factom Work
+#How Factom Works
 
 ![Figure 1](images/fig1.png)
 
-*Figure 1: Diagram showing that Factom Blocks are linked together, and the has of each Factom Block is inserted into the Bitcoin Block Chain.*
+*Figure 1: Diagram showing that Factom Blocks are linked together, and the hash of each Factom Block is inserted into the Bitcoin blockchain.*
 
-The proof of existence hashes are held within a series of Factom Blocks.  Every so often, the current Factom block is hashed, and that hash is inserted into the Bitcoin Block Chain, as shown by Figure 1.  The periodic hash is all that is inserted into the Bitcoin Blockchain.  With the single hash, the Factom Block can be provably unalterable (as it would break the hash recorded in the Bitcoin Block Chain).  We are looking at different ways to create a link to this hash from the Factom block. 
+The proof of existence hashes are held within a series of Factom Blocks.  Every so often, the current Factom block is hashed, and that hash is inserted into the Bitcoin blockchain, as shown by Figure 1.  The periodic hash is all that is inserted into the blockchain.  With the single hash, the Factom Block can be provably unalterable (as it would break the hash recorded in the blockchain).  We are looking at different ways to create a link to this hash from the Factom block. 
 
-A Factom Block is created immediately after the previous Factom Block is slated to have its Hash submitted to the Bitcoin BlockChain.  A new Factom Block begins with a Block ID (one greater than the last).
+A Factom Block is created immediately after the previous Factom Block is slated to have its Hash submitted to the blockchain.  A new Factom Block begins with a Block ID (one greater than the last).
 
 ![Figure 2](images/fig2.png)
 
@@ -169,30 +169,30 @@ As each Factom Entry is submitted, it is added to the Factom Block, along with a
 
 #A Simple Factom Entry
 
-Any number of Factom entries can be added to a Factom Block, and remain secured by the Bitcoin Blockchain.  This vastly reduces the overhead of Factom functions on the Bitcoin Blockchain without significant loss of security for the Factom entries themselves.  We will discuss how the Factom Blocks are published in a later section.  But suffice it to say that anyone holding a copy of a Factom Block can prove its validity by simply providing the Bitcoin Transaction holding the block’s hash.  The block could not possibly have been constructed after the fact (as fitting a block’s contents to produce an existing hash is quite out of the question).  The Bitcoin Transaction holding the Factom Block’s hash + a copy of the Factom Block will fix the existence of a document at a point in time, and prove the document has not been altered.
+Any number of Factom entries can be added to a Factom Block, and remain secured by the Bitcoin blockchain.  This vastly reduces the overhead of Factom functions on the blockchain without significant loss of security for the Factom entries themselves.  We will discuss how the Factom Blocks are published in a later section.  But suffice it to say that anyone holding a copy of a Factom Block can prove its validity by simply providing the Bitcoin Transaction holding the block’s hash.  The block could not possibly have been constructed after the fact (as fitting a block’s contents to produce an existing hash is quite out of the question).  The Bitcoin Transaction holding the Factom Block’s hash + a copy of the Factom Block will fix the existence of a document at a point in time, and prove the document has not been altered.
 
 ![Figure 3](images/fig3.png)
 
 *Figure 3: Internal structure of a Factom Entry*
 
-Figure 3 shows a simple Factom Entry.  It is composed of structured data (pretty much whatever data the user wants to provide), a reverse hash (a token system used by Factom to control access) and one or more signatures.  A simple entry has does not receive any validity checking by the FactomChain server outside of verifying the signatures, if any are provided.  The user provides the entry, structured data, and the signatures (if desired) for the structured data.  If signatures are provided, but do not validate against the structured data provided, then the entry will be rejected. The FactomChain hashes the entry and signatures, then adds that hash to the Factom block (per figure 2).  The Factom block adds the entry type 1 (simple entry) and the time stamp at the Factom block level.
+Figure 3 shows a simple Factom Entry.  It is composed of structured data (pretty much whatever data the user wants to provide), a reverse hash (a token system used by Factom to control access) and one or more signatures.  A simple entry does not receive any validity checking by the FactomChain server outside of verifying the signatures, if any are provided.  The user provides the entry, structured data, and the signatures (if desired) for the structured data.  If signatures are provided, but do not validate against the structured data provided, then the entry will be rejected. The FactomChain hashes the entry and signatures, then adds that hash to the Factom block (per figure 2).  The Factom block adds the entry type 1 (simple entry) and the time stamp at the Factom block level.
 
 While a user can use the Structured Data section to implement a range of protocols like tokens, smart contracts, smart properties, etc., Factom provide some generic support for these features.  The support for Factom within FactomChain servers is necessary to make the FactomChain Servers auditable in real time for many common functions by its users, and by other Federated FactomChain Servers.   Federated FactomChain servers provide the redundancy and cross checking required for the security of many applications that may wish to run on top of Factom.
 
 
-# How to create a Factom Chain
+# How to Create a Factom Chain
 
-Factom are chains of Factom Entries. A Factom Chain provides the infrastructure for managing smart contracts, token counts, alternative currencies, etc.  
+Factom Chains are chains of Factom Entries. A Factom Chain provides the infrastructure for managing smart contracts, token counts, alternative currencies, etc.  
 
 ![Figure 4](images/fig4.png)
 
-*Figure 4] Structure of the first link in a Factom Chain, i.e. a chain of Factom entries*
+*Figure 4: Structure of the first link in a Factom Chain, i.e., a chain of Factom entries*
 
 A Start Link begins a Factom Chain.  It looks just like a simple entry, but is typed as a chain.  (The specification for the types for chains is under discussion.) The Structured Description must include a “VScript” entry.   Many chains could be validated privately.  In other words, the validation rules for the chain can be published (and notarized via the Start Link) and any attempt to fraudulently add links to the chain are invalidated by the rules published by the parties starting the FactomChain.  In fact, a reference implementation of an application that validates a FactomChain should be hashed and secured in the Start Link for a FactomChain. That application in combination with the published rules for the FactomChain, rather than the FactomChain server, would be responsible for validating that FactomChain. 
 
-Still, there is some use in creating an Account FactomChain supported by FactomChain servers, if for no other reason that to allow the group purchase of Factom entries by users of Factom.   Because of the reduced overhead of Factom, these can be made available at rates far cheaper than Bitcoin Transactions.
+Still, there is some use in creating an Account FactomChain supported by FactomChain servers, if for no other reason than to allow the group purchase of Factom entries by users of Factom.   Because of the reduced overhead of Factom, these can be made available at rates far cheaper than Bitcoin Transactions.
 
-An Account FactomChain is enforced by the FactomChain Server.  And it serves as an example for creating user defined chains.  The Start Link for an Account Factom Chain might look like this:
+An Account FactomChain is enforced by the FactomChain Server.  And it serves as an example for creating user-defined chains.  The Start Link for an Account Factom Chain might look like this:
 
 ```
 NE Type: 	Start Link
@@ -217,12 +217,12 @@ A Factom Link points back to its parent links.  The Validation Script (part of t
 
 #FactomChain Servers
 
-FactomChain servers are federated under one of the FactomChain servers, the Master Factom server.  They register their Factom Blocks with the Master Factom server, and validate the other Factom servers.  Payments for Factom services are managed with Factom Chains and accounts are settled by payments that are made periodically.   Payments can be in Bitcoin, various alt currencies, or even traditional currencies (though that is less likely).  Half of a payment for Factom services should go to the Factom Server accepting payment, and the other half distributed to all the Factom servers providing auditing services.
+FactomChain servers are federated under one of the FactomChain servers, the Master Factom server.  They register their Factom Blocks with the Master Factom server, and validate the other Factom servers.  Payments for Factom services are managed with Factom Chains, and accounts are settled by payments that are made periodically.   Payments can be in bitcoin, various alt currencies, or even traditional currencies (though that is less likely).  Half of a payment for Factom services should go to the Factom Server accepting payment, and the other half distributed to all the Factom servers providing auditing services.
 
-Each Factom Server must provide access to their Factom Blocks to the other Factom Servers as well as to their users and customers.  For now, access can be provided via websites and torrents.  In the future, they can be provided by MaidSafe and the Safe Network. 
+Each Factom Server must provide access to their Factom Blocks to the other Factom Servers as well as to their users and customers.  For now, access can be provided via websites and torrents.  In the future, they can be provided by MaidSafe and the SAFE Network. 
 
-#Crowd funding
-Factom will use a token system for paying for entries to be placed on into Factom blocks secured by Factom.  Some token is necessary to prevent spamming or attacking the system.  
+#Crowd Funding
+Factom will use a token system for paying for entries to be placed into Factom blocks secured by Factom.  Some token is necessary to prevent spamming or attacking the system.  
 
 ##Factom Coins (XNC)
 Factom Coins will be used for paying to create FactomChain Specifications, start new Factom using those specifications, and adding entries into Factom.  Factom Coins will be tracked in a Factom Chain, and will be generated to provide incentives for running the Federated Factom Chain servers, run independent audits, and other behaviors.  Because Factom Coins are tracked on Factom Chain servers directly, they can be used to automate payments for entries and chains directly.


### PR DESCRIPTION
Made consistent use of "blockchain" versus "block chain". Arguably, the choice is arbitrary, but this whitepaper should be consistent.  Also removed some instances of capitalization of Blockchain.  There were several uses of "Bitcoin blockchain" where "Bitcoin" was unnecessary to disambiguate.  (Nowhere in this paper is the Factom Chain referred to as a block chain.)

Note there were several uses of Factom as grammatically plural, e.g. "Factom keep" and "Factom also limit" and "How Factom Work".  I considered suggesting what I think was meant to be a plural concept in these contexts such as "Factom Chains"; however, I was not sure enough so I usually just made the verb tense correct.
