### PR TITLE
Entry and Chain Commit Signature Wording Clarification

### DIFF
--- a/factomDataStructureDetails.md
+++ b/factomDataStructureDetails.md
@@ -112,7 +112,7 @@ An Entry Commit is a payment for a specific Entry. It deducts a balance held by 
 | 32 bytes | Entry Hash | This is the SHA512+256 descriptor of the Entry to be paid for. |
 | 1 byte | Number of Entry Credits | This is the number of Entry Credits which will be deducted from the balance of the public key. Any values above 10 are invalid. |
 | 32 bytes | Pubkey | This is the Entry Credit public key which will have the balance reduced. It is the ed25519 A value. |
-| 64 bytes | Signature | This is a signature of this Entry Commit by the pubkey.  Parts ordered R then S. Signature covers from Version through 'Number of Entry Credits' |
+| 64 bytes | Signature | This is a signature of this Entry Commit by the Entry Credit private key corresponding to pubkey.  Parts ordered R then S. Signature covers from Version through 'Number of Entry Credits' |
 
 The Entry Commit is only valid for 12 hours before and after the milliTimestamp. Since Entry Credits are balance based, replay attacks can reduce balances. Also a user can pay for the same Entry twice, and have two copies in Factom. Since a P2P network is used, the payments would need to be differentiated. The payments would be differentiated by public key and the time specified. This puts a limit of 1000 per second on any individual Entry Credit public key per duplicate Entry. The milliTimestamp also helps the network protect itself.  Adding the time element allows peers to automatically reject payments beyond 12 hours plus or minus. This means they must check for duplicates only over a rolling one day period. 
 

--- a/factomDataStructureDetails.md
+++ b/factomDataStructureDetails.md
@@ -133,7 +133,7 @@ A Chain Commit is a simultaneous payment for a specific Entry and a payment to a
 | 32 bytes | Entry Hash | This is the SHA512+256 descriptor of the Entry to be the first in the Chain. |
 | 1 byte | Number of Entry Credits | This is the number of Entry Credits which will be deducted from the balance of the public key. Any values above 20 or below 11 are invalid. |
 | 32 bytes | Pubkey | This is the Entry Credit public key which will have the balance reduced. |
-| 64 bytes | Signature | This is a signature of this Chain Commit by the pubkey.  Parts ordered R then S. Signature covers from Version through 'Number of Entry Credits' |
+| 64 bytes | Signature | This is a signature of this Chain Commit by the Entry Credit private key corresponding to pubkey.  Parts ordered R then S. Signature covers from Version through 'Number of Entry Credits' |
 
 The Federated server will keep track of the Chain Commits based on ChainID Hash. The Federated servers keep track of the Chain Commits they receive.  When the first Entry is received, it will reveal the ChainID.  If the ChainID was a secret, then it now can be compared against all the possible Chain Commits claiming to pay for Entries of a certain ChainID. Once the ChainID is revealed, the ChainID hash and the 'Entry Hash + ChainID' fields can be compared to see if they match and form valid hashes. If they do not match, that Chain Commit is invalid.  If they do match, then the first one to be acknowledged gets accepted as the first Entry.  They maintain exclusivity for 1 hour for each ChainID hash after an acknowledgement.  The commit itself must be within 12 hours +/- of the milliTimestamp.
 


### PR DESCRIPTION
This PR clarifies some confusing wording in the Signature description sections of Chain Commit and Entry Commit. 