### PR TITLE
Minor clarification of ExtID with zero length

### DIFF
--- a/factomDataStructureDetails.md
+++ b/factomDataStructureDetails.md
@@ -52,7 +52,7 @@ External IDs and Content is not checked for validity, or sanitized, as it is onl
 | 2 bytes | ExtIDs Size | Describes how many bytes required for the set of External IDs for this Entry.  Must be less than or equal to the Payload size.  Big endian. |
 | **Payload** | | This is the data between the end of the Header and the end of the Content. |
 | **External IDs** |  | This section is only interpreted and enforced if the External ID Size is greater than zero. |
-| 2 bytes | ExtID element 0 length | This is the number of the following bytes to be interpreted as an External ID element.  Cannot be 0 length. |
+| 2 bytes | ExtID element 0 length | This is the number of the following bytes to be interpreted as an External ID element.  Can be 0 length. |
 | variable | ExtID 0 | This is the data for the first External ID. |
 | 2 bytes | ExtID X | Size of the X External ID  |
 | variable | ExtID X data | This is the Xth element.  The last byte of the last element must fall on the last byte specified ExtIDs Size in the header. |


### PR DESCRIPTION
(thanks to @ilzheev for this discovery)

It is currently possible to add zero-length ExtIDs and both the factom client and factomd handle them fine.

Example: https://explorer.factom.pro/chains/98133e8546d2ced588807803795b1bad5d7cfa2faa0371bfcf5e560ccf5add29

![image](https://user-images.githubusercontent.com/34172041/86017421-4f491500-ba24-11ea-9239-bb246702f0d4.png)


This entry has three ExtIDs that are zero length. Raw data: `0098133e8546d2ced588807803795b1bad5d7cfa2faa0371bfcf5e560ccf5add2900090000000000000001de224e657720636861696e2e22`



```
          Version: 00
         Chain ID: 98133e8546d2ced588807803795b1bad5d7cfa2faa0371bfcf5e560ccf5add29
      ExtID Bytes: 0009
Length of ExtID 1: 0000 
Length of ExtID 2: 0000
Length of ExtID 3: 0000
Length of ExtID 4: 0001
  Data of ExtID 4: de
          Content: 224e657720636861696e2e22
```